### PR TITLE
ci: Replace pull_request_target with pull_request in GitHub Actions

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,7 +1,7 @@
 name: Auto Author Assign
 
 on:
-  pull_request_target:
+  pull_request:
     types: [ opened, reopened ]
 
 concurrency:

--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   assign-author:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.1

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -7,7 +7,7 @@ on:
       - edited
       - closed
       - reopened
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -24,6 +24,7 @@ concurrency:
 
 jobs:
   check:
+    if: github.event_name == 'issues' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: z0al/dependent-issues@v1.5.2

--- a/.github/workflows/semantic-commit.yml
+++ b/.github/workflows/semantic-commit.yml
@@ -1,6 +1,6 @@
 name: 'PR and Commit Message Check'
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Description

Replace `pull_request_target` with `pull_request` in GitHub Actions workflows.

### Why

`pull_request_target` runs in the context of the base branch with full access to repository secrets, even for fork PRs. This is unnecessary and a potential security risk for workflows that only need read access (semantic commit check, dependent issues, auto-author assign).

Since all PRs come from within the organization, `pull_request` is sufficient.

### Changes
- `.github/workflows/dependent-issues.yml` (if present):  `pull_request_target` → `pull_request`
- `.github/workflows/auto-author-assign.yml` (if present):  `pull_request_target` → `pull_request`
- `.github/workflows/semantic-commit.yml` (if present): `pull_request_target` → `pull_request`